### PR TITLE
Almost working workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,4 @@ jobs:
         with:
           target: 'http://localhost:8000'
   
+ 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,7 @@ jobs:
     #startup PIXI using the docker-compose up command
       - name: Build the image
         id: build-image
-        run: |
-          echo "Building docker image..."
-          docker-compose up > /dev/null 2>&1 
-          echo "Image built... sleeping"
-          sleep 30
-          echo "I'm awake!"
+        run: docker-compose up
   
       - name: OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.4.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build the image
         id: build-image
         run: |
-          echo "Building docker image..."'
+          echo "Building docker image..."
           docker-compose up > /dev/null 2>&1 
           echo "Image built... sleeping"
           sleep 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 # We have many jobs
 jobs:
     deploy:
-      name: Deploy
+      name: Deploy and test Pixi
       runs-on: ubuntu-latest
   
       steps:
@@ -21,8 +21,8 @@ jobs:
         uses: actions/checkout@v2
   
     #startup PIXI using the docker-compose up command
-      - name: Build the image
-        id: build-image
+      - name: Start the containers
+        id: start-containers
         run: docker-compose up -d
   
       - name: Sleep to allow containers to mellow
@@ -34,4 +34,8 @@ jobs:
         with:
           target: 'http://localhost:8000'
   
- 
+     #stop PIXI using docker-compose down
+      - name: Stop the containers
+        id: stop-containers
+        run: docker-compose down
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,12 @@ jobs:
     #startup PIXI using the docker-compose up command
       - name: Build the image
         id: build-image
-        run: docker-compose up
+        run: docker-compose up -d
   
+      - name: Sleep to allow containers to mellow
+        id: sleep-mellow
+        run: sleep 30
+
       - name: OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.4.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,45 +24,14 @@ jobs:
       - name: Build the image
         id: build-image
         run: |
-          printf "starting 10 minute timer printf"
-          echo 'starting 10 minute timer'
-          docker-compose up & sleep 6000 
-          echo 'this worked - timer done'
-          printf "this worked - timer done printf"
-  #sleep 10 minutes to let PIXI start and update herself
+          echo "Building docker image..."'
+          docker-compose up > /dev/null 2>&1 
+          echo "Image built... sleeping"
+          sleep 30
+          echo "I'm awake!"
   
       - name: OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.4.0
         with:
           target: 'http://localhost:8000'
   
-  
-  
-#kill the PIXI docker container after tests are complete
-      - name: Stop the image
-        id: kill-image
-        run: |
-          docker-compose down
-
-
-
-    #tests:
-      #name: tests
-      #runs-on: ubuntu-latest
-  
-      #steps:
-      #- name: Checkout
-      #  uses: actions/checkout@v1
-
-      #tests-go-here
-      #SCA    
-      #- name: Snyk
-      #  uses: snyk/actions/dotnet@master
-      #  env:
-      #     SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-         
-
-
-
-


### PR DESCRIPTION
This starts Pixi, runs the test suite and tears down the containers (though that may be unnecesssary). Currently errors because the test action I think is trying to create github issues for the problems it found. But the structure should be re-usable.